### PR TITLE
#13 OSDI Action Network import merge

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,11 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Metrics/AbcSize:
+  Max: 30
+
 Metrics/LineLength:
   Max: 160
 
 Metrics/MethodLength:
-  Max: 20  
+  Max: 20

--- a/app/models/api/events.rb
+++ b/app/models/api/events.rb
@@ -1,3 +1,63 @@
 class Api::Events
   attr_accessor :events
+
+  # Import events from Action Network OSDI API.
+  # Requires ACTION_NETWORK_API_TOKEN set in ENV.
+  # There are no external endpoints for this method yet.
+  def self.import!
+    logger.info 'Api::Events#import! from https://actionnetwork.org/api/v2/events'
+
+    events = request_events_from_action_network
+
+    Event.transaction do
+      existing_events, new_events = partition_events(events)
+      updated_count = update_events(existing_events)
+      logger.debug "Api::Events#import! new: #{new_events.size} existing: #{existing_events.size} updated: #{updated_count}"
+      new_events.each(&:save!)
+    end
+  end
+
+  def self.request_events_from_action_network
+    events = Api::Events.new
+    client = Api::EventsRepresenter.new(events)
+    client.get(uri: 'https://actionnetwork.org/api/v2/events', as: 'application/json') do |request|
+      request['OSDI-API-TOKEN'] = Rails.application.secrets.action_network_api_token
+    end
+
+    logger.debug "Api::Events#import! events: #{events.events.size}"
+    events.events
+  end
+
+  def self.partition_events(events)
+    events.partition do |event|
+      action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
+      Event.identifier(action_network_identifier).exists?
+    end
+  end
+
+  # Update all attributes for events that already exist and have not been modified after import
+  # We may want to do something different
+  def self.update_events(existing_events)
+    updated_count = 0
+    existing_events.each do |event|
+      action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
+      old_event = Event
+                  .identifier(action_network_identifier)
+                  .where('updated_at < ?', event.updated_at)
+                  .first
+
+      if old_event
+        updated_count += 1
+        attributes = event.attributes
+        attributes.delete_if { |k, v| v.nil? }
+        old_event.update_attributes! attributes
+      end
+    end
+
+    updated_count
+  end
+
+  def self.logger
+    Event.logger
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,47 +12,6 @@ class Event < ApplicationRecord
 
   scope :identifier, ->(identifier) { where('? = any (identifiers)', identifier) }
 
-  # Import events from Action Network OSDI API.
-  # Requires ACTION_NETWORK_API_TOKEN set in ENV.
-  # There are no external endpoints for this method yet.
-  def self.import!
-    logger.info 'Event#import! from https://actionnetwork.org/api/v2/events'
-
-    events = Api::Events.new
-    client = Api::EventsRepresenter.new(events)
-    client.get(uri: 'https://actionnetwork.org/api/v2/events', as: 'application/json') do |request|
-      request['OSDI-API-TOKEN'] = Rails.application.secrets.action_network_api_token
-    end
-
-    logger.debug "Event#import! events: #{events.events.size}"
-
-    transaction do
-      existing_events, new_events = events.events.partition do |event|
-        action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
-        Event.identifier(action_network_identifier).exists?
-      end
-
-      updated_count = 0
-      existing_events.each do |event|
-        action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
-        old_event = Event
-                    .identifier(action_network_identifier)
-                    .where('updated_at < ?', event.updated_at)
-                    .first
-
-        if old_event
-          updated_count += 1
-          attributes = event.attributes
-          attributes.delete_if { |k, v| v.nil? }
-          old_event.update_attributes! attributes
-        end
-      end
-      logger.debug "Event#import! new: #{new_events.size} existing: #{existing_events.size} updated: #{updated_count}"
-
-      new_events.each(&:save!)
-    end
-  end
-
   def add_identifier
     identifier = "advocacycommons:#{id}"
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,23 +10,46 @@ class Event < ApplicationRecord
 
   after_save :add_identifier
 
+  scope :identifier, ->(identifier) { where('? = any (identifiers)', identifier) }
+
   # Import events from Action Network OSDI API.
   # Requires ACTION_NETWORK_API_TOKEN set in ENV.
   # There are no external endpoints for this method yet.
   def self.import!
+    logger.info 'Event#import! from https://actionnetwork.org/api/v2/events'
+
     events = Api::Events.new
     client = Api::EventsRepresenter.new(events)
     client.get(uri: 'https://actionnetwork.org/api/v2/events', as: 'application/json') do |request|
       request['OSDI-API-TOKEN'] = Rails.application.secrets.action_network_api_token
     end
 
-    events = events.events.reject do |event|
-      action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
-      Event.where('? = any (identifiers)', action_network_identifier).exists?
-    end
+    logger.debug "Event#import! events: #{events.events.size}"
 
     transaction do
-      events.each(&:save!)
+      existing_events, new_events = events.events.partition do |event|
+        action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
+        Event.identifier(action_network_identifier).exists?
+      end
+
+      updated_count = 0
+      existing_events.each do |event|
+        action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
+        old_event = Event
+                    .identifier(action_network_identifier)
+                    .where('updated_at < ?', event.updated_at)
+                    .first
+
+        if old_event
+          updated_count += 1
+          attributes = event.attributes
+          attributes.delete_if { |k, v| v.nil? }
+          old_event.update_attributes! attributes
+        end
+      end
+      logger.debug "Event#import! new: #{new_events.size} existing: #{existing_events.size} updated: #{updated_count}"
+
+      new_events.each(&:save!)
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,7 +25,9 @@ class Event < ApplicationRecord
       Event.where('? = any (identifiers)', action_network_identifier).exists?
     end
 
-    events.each(&:save!)
+    transaction do
+      events.each(&:save!)
+    end
   end
 
   def add_identifier

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,7 +19,13 @@ class Event < ApplicationRecord
     client.get(uri: 'https://actionnetwork.org/api/v2/events', as: 'application/json') do |request|
       request['OSDI-API-TOKEN'] = Rails.application.secrets.action_network_api_token
     end
-    events.events.each(&:save!)
+
+    events = events.events.reject do |event|
+      action_network_identifier = event.identifiers.detect { |identifier| identifier['action_network:'] }
+      Event.where('? = any (identifiers)', action_network_identifier).exists?
+    end
+
+    events.each(&:save!)
   end
 
   def add_identifier

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -29,12 +29,13 @@ one:
   creator_id: 1
   organizer_id: 1
   modified_by_id: 1
+  identifiers: ['advocacycommons:1']
 
 two:
   id: 2
   origin_system: MyString
   name: MyString
-  title: MyString
+  title: House Party for Progress
   description: MyString
   summary: MyString
   browser_url: MyString
@@ -59,3 +60,4 @@ two:
   creator_id: 2
   organizer_id: 2
   modified_by_id: 2
+  identifiers: ['action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e', 'advocacycommons:2']

--- a/test/fixtures/files/events.json
+++ b/test/fixtures/files/events.json
@@ -203,6 +203,69 @@
                         "href": "https://actionnetwork.org/api/v2/events/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_attendance_helper"
                     }
                 }
+            },
+            {
+                "identifiers": [
+                    "action_network:a3c724db-2799-49a6-970a-7c3c0844645d"
+                ],
+                "origin_system": "OSDI Sample System",
+                "created_date": "2014-03-20T20:44:13Z",
+                "modified_date": "2015-04-20T20:19:09Z",
+                "title": "Teach in",
+                "description": "Educate yourself",
+                "instructions": "<p>This is an invite-only event, but feel free to bring a friend!</p>",
+                "browser_url": "http://actionnetwork.org/events/party-for-progress",
+                "type": "open",
+                "status": "tentative",
+                "start_date": "2015-01-05T19:00:00Z",
+                "end_date": "2015-01-05T21:00:00Z",
+                "all_day": false,
+                "guests_can_invite_others": false,
+                "capacity": 10,
+                "transparence": "opaque",
+                "visibility": "private",
+                "location": {
+                    "venue": "My House",
+                    "address_lines": [
+                        "1600 Pennsylvania Ave. NW"
+                    ],
+                    "locality": "Washington",
+                    "region": "DC",
+                    "postal_code": "20001",
+                    "country": "US",
+                    "language": "EN",
+                    "location": {
+                        "latitude": 38.9002101,
+                        "longitude": -77.0359252,
+                        "accuracy": "Rooftop"
+                    }
+                },
+                "reminders": [
+                    {
+                        "method": "email",
+                        "minutes": 1440
+                    }
+                ],
+                "_links": {
+                    "self": {
+                        "href": "https://actionnetwork.org/api/v2/events/a3c724db-2799-49a6-970a-7c3c0844645d"
+                    },
+                    "osdi:attendances": {
+                        "href": "https://actionnetwork.org/api/v2/events/1efc3644-af25-4253-90b8-a0baf12dbd1e/attendances"
+                    },
+                    "osdi:creator": {
+                        "href": "https://actionnetwork.org/api/v2/people/65345d7d-cd24-466a-a698-4a7686ef684f"
+                    },
+                    "osdi:organizer": {
+                        "href": "https://actionnetwork.org/api/v2/people/8a625981-67a4-4457-8b55-2e30b267b2c2"
+                    },
+                    "osdi:modified_by": {
+                        "href": "https://actionnetwork.org/api/v2/people/c945d6fe-929e-11e3-a2e9-12313d316c29"
+                    },
+                    "osdi:record_attendance_helper": {
+                        "href": "https://actionnetwork.org/api/v2/events/1efc3644-af25-4253-90b8-a0baf12dbd1e/record_attendance_helper"
+                    }
+                }
             }
         ]
     }

--- a/test/fixtures/files/events.json
+++ b/test/fixtures/files/events.json
@@ -28,7 +28,7 @@
         "osdi:events": [
             {
                 "identifiers": [
-                    "osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
+                    "action_network:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
                     "foreign_system:1"
                 ],
                 "origin_system": "OSDI Sample System",
@@ -120,7 +120,7 @@
             },
             {
                 "identifiers": [
-                    "osdi_sample_system:1efc3644-af25-4253-90b8-a0baf12dbd1e"
+                    "action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e"
                 ],
                 "origin_system": "OSDI Sample System",
                 "created_date": "2014-03-20T20:44:13Z",

--- a/test/models/api/event_test.rb
+++ b/test/models/api/event_test.rb
@@ -6,7 +6,10 @@ class Api::EventTest < ActiveSupport::TestCase
       .with(headers: { 'OSDI-API-TOKEN' => 'test-token' })
       .to_return(body: File.read("#{Rails.root}/test/fixtures/files/events.json"))
 
-    assert_difference 'Event.count', 2 do
+    assert Event.where(title: 'House Party for Progress').exists
+    assert Event.where(identifiers: 'action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e').exists
+
+    assert_difference 'Event.count', 1 do
       Event.import!
     end
 
@@ -18,7 +21,7 @@ class Api::EventTest < ActiveSupport::TestCase
     assert_equal 'open', march_14_event.osdi_type
 
     expected_identifiers = [
-      'osdi_sample_system:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3',
+      'action_network:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3',
       'foreign_system:1',
       "advocacycommons:#{march_14_event.id}"
     ].sort

--- a/test/models/api/event_test.rb
+++ b/test/models/api/event_test.rb
@@ -6,8 +6,15 @@ class Api::EventTest < ActiveSupport::TestCase
       .with(headers: { 'OSDI-API-TOKEN' => 'test-token' })
       .to_return(body: File.read("#{Rails.root}/test/fixtures/files/events.json"))
 
+    travel_to Time.zone.local(2001) do
+      Event.create!(
+        title: 'TBD',
+        identifiers: ['action_network:a3c724db-2799-49a6-970a-7c3c0844645d']
+      )
+    end
+
     assert Event.where(title: 'House Party for Progress').exists
-    assert Event.where(identifiers: 'action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e').exists
+    assert Event.identifier('action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e').exists
 
     assert_difference 'Event.count', 1 do
       Event.import!
@@ -26,5 +33,8 @@ class Api::EventTest < ActiveSupport::TestCase
       "advocacycommons:#{march_14_event.id}"
     ].sort
     assert_equal expected_identifiers, march_14_event.identifiers&.sort, 'identifiers'
+
+    updated_event = Event.identifier('action_network:a3c724db-2799-49a6-970a-7c3c0844645d').first!
+    assert_equal 'Teach in', updated_event.title, 'Should update title'
   end
 end

--- a/test/models/api/events_test.rb
+++ b/test/models/api/events_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Api::EventTest < ActiveSupport::TestCase
+class Api::EventsTest < ActiveSupport::TestCase
   test '.import!' do
     stub_request(:get, 'https://actionnetwork.org/api/v2/events')
       .with(headers: { 'OSDI-API-TOKEN' => 'test-token' })
@@ -17,7 +17,7 @@ class Api::EventTest < ActiveSupport::TestCase
     assert Event.identifier('action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e').exists
 
     assert_difference 'Event.count', 1 do
-      Event.import!
+      Api::Events.import!
     end
 
     assert Event.where(name: 'March 14th Rally').exists


### PR DESCRIPTION
Sensibly handle an AN import
 * create new events
 * merge attributes from more recent versions of existing events
 * ignore existing, unchanged events

Also restructure the import code a bit.

I tested this with the API key and it worked! 🎉 
`DISABLE_SPRING=1 ACTION_NETWORK_API_TOKEN=${token} rails r 'Api::Events.import!'`

(The DISABLE_SPRING is needed if ACTION_NETWORK_API_TOKEN wasn't set before Rails Spring started)