### PR TITLE
Use person hashed primary email as affinity identifier.

### DIFF
--- a/app/models/concerns/api/identifiers.rb
+++ b/app/models/concerns/api/identifiers.rb
@@ -12,18 +12,19 @@ module Api::Identifiers
     scope :outdated_existing, ->(record, system_prefix) { any_identifier(record.identifier(system_prefix)).where('updated_at < ?', record.updated_at) }
   end
 
-  def add_identifier
-    identifier = "advocacycommons:#{id}"
+  # Add or update the given identifier
+  def add_identifier(system_prefix='advocacycommons', value=id)
+    identifier_to_add = "#{system_prefix}:#{value}"
 
     if identifiers.nil?
-      self.identifiers = [identifier]
-      save
-    elsif identifiers.include?(identifier)
-      true
+      self.identifiers = [identifier_to_add]
+    elsif identifiers.include?(identifier_to_add)
+      identifiers.delete(identifier(system_prefix))
+      identifiers << identifier_to_add
     else
-      identifiers << identifier
-      save
+      identifiers << identifier_to_add
     end
+    save
   end
 
   def identifier(system_prefix)

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -7,7 +7,18 @@ class EmailAddress < ApplicationRecord
 
   belongs_to :person
 
+  before_save :update_person_identifier
+
   def valid_address_format?
     address.present? && address.match(ADDRESS_FORMAT)
+  end
+
+  private
+
+  def update_person_identifier
+    if address_changed? && primary?
+      hashed_address = Digest::SHA256.base64digest address
+      self.person.add_identifier('affinity_id', hashed_address)
+    end
   end
 end

--- a/test/models/email_address_test.rb
+++ b/test/models/email_address_test.rb
@@ -10,4 +10,11 @@ class EmailAddressTest < ActiveSupport::TestCase
     address = EmailAddress.new
     assert_not address.save
   end
+
+  test 'should update person identifier when primary email changes' do
+    person = people(:one)
+    email_address = EmailAddress.create(primary: true, person: person, address: 'example@example.com')
+    hashed_address = Digest::SHA256.base64digest email_address.address
+    assert_equal hashed_address, person.identifier_id('affinity_id')
+  end
 end


### PR DESCRIPTION
Issue #16 