### PR TITLE
Redirect non organizer group members to group public page after logs in.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,8 +24,10 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     if resource.admin?
       admin_dashboard_path
-    else
+    elsif can? :manage, current_group
       events_path
+    else
+      group_url(id: current_group.id)
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,10 @@ class Ability
       can :read, Attendance do |attendance|
         attendance.person.groups.include?(current_group)
       end
+
+      can :manage, Group do
+        person.memberships.organizer.collect(&:group).include?(current_group)
+      end
     end
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -3,4 +3,7 @@ class Membership < ApplicationRecord
   belongs_to :person
 
   enum role: [:member, :organizer]
+
+  scope :organizer, -> () { where(role: 'organizer') }
+  scope :member, -> () { where(role: 'member') }
 end

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -30,4 +30,18 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can? :read, group_attendance, 'current person is able to read current group\'s attendances'
     assert_not ability.can? :read, Attendance.last, 'current person is not able to read current group\'s attendances'
   end
+
+  test 'can manage current group' do
+    organizer = Membership.organizer.first.person
+    current_group = Membership.organizer.first.group
+    ability = Ability.new(organizer, current_group)
+    assert ability.can? :manage, Group, 'the user can manage current group if has role organizer'
+  end
+
+  test 'can not manage current group' do
+    member = Membership.member.first.person
+    current_group = Membership.member.first.group
+    ability = Ability.new(member, current_group)
+    assert_not ability.can? :manage, current_group, 'the user can manage current group if has role member'
+  end
 end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -10,7 +10,17 @@ class MembershipTest < ActiveSupport::TestCase
     assert_kind_of Membership, one.group.memberships.first
 
     assert_kind_of Group, one.person.groups.first
-    
+
     #assert_kind_of Person, one.group.members.first
+  end
+
+  test '#organizer' do
+    organizers = Membership.where(role: 'organizer')
+    assert_equal Membership.organizer, organizers
+  end
+
+  test '#member' do
+    members = Membership.where(role: 'member')
+    assert_equal Membership.member, members
   end
 end


### PR DESCRIPTION
related to #104. Please let me know if I misunderstood the roles. Because right now we have `member` and `organizer` inside the Membership and `admin` inside the Person.