### PR TITLE
262 group name on all members

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -84,3 +84,7 @@
 .add-tag-container {
   margin-bottom: 15px;
 }
+
+.group-list {
+  margin-right: 10px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,11 @@ class ApplicationController < ActionController::Base
   end
 
   def current_group
-    current_person.groups.first
+    if params[:group_id ] then
+      return Group.find(params[:group_id])
+    else
+      return current_person.groups.first
+    end
   end
 
   def current_role

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,6 +9,11 @@ class Group < ApplicationRecord
   #this doesn't seem right...
   has_many :attendances, through: :members
 
+
+  has_many :affiliations
+  has_many :affilated_with, through: :affiliations, source: :affiliated_with
+  has_many :affiliates, through: :affiliations, source: :affiliates
+
   has_and_belongs_to_many :events
   has_and_belongs_to_many :advocacy_campaigns
   has_and_belongs_to_many :canvassing_efforts

--- a/app/representers/json_api/member_representer.rb
+++ b/app/representers/json_api/member_representer.rb
@@ -1,0 +1,16 @@
+require 'roar/json/json_api'
+
+class JsonApi::MemberRepresenter < Roar::Decorator
+  include Roar::JSON::JSONAPI.resource :people
+
+  attributes do
+    property :family_name
+    property :given_name
+    property :primary_email_address
+    property :primary_phone_number
+    property :attended_events_count
+    property :primary_personal_address, decorator: Api::Resources::AddressRepresenter, class: PersonalAddress
+  end
+
+  has_many :groups, extend: JsonApi::MembershipGroupRepresenter
+end

--- a/app/representers/json_api/membership_group_representer.rb
+++ b/app/representers/json_api/membership_group_representer.rb
@@ -1,0 +1,8 @@
+require 'roar/json/json_api'
+
+class JsonApi::MembershipGroupRepresenter < Roar::Decorator
+  include Roar::JSON
+
+  property :name
+  property :id
+end

--- a/app/representers/json_api/membership_representer.rb
+++ b/app/representers/json_api/membership_representer.rb
@@ -6,7 +6,7 @@ class JsonApi::MembershipRepresenter < Roar::Decorator
   attributes do
     property :role
 
-    property :person, extend: JsonApi::PeopleRepresenter, class: Person
+    property :person, extend: JsonApi::MemberRepresenter, class: Person
     property :group, extend: JsonApi::GroupsRepresenter, class: Group
   end
 end

--- a/client/app/bundles/Events/actions/MembershipsActions.jsx
+++ b/client/app/bundles/Events/actions/MembershipsActions.jsx
@@ -4,8 +4,10 @@ import {
   FETCH_MEMBERSHIPS
 } from './types';
 
+import { membershipPath } from '../utils/Pathnames';
+
 export const fetchMemberships = (queryString = '') => {
-  const request = axios.get(`/memberships.json${queryString}`);
+  const request = axios.get(`${membershipPath()}.json${queryString}`);
 
   return {
     type: FETCH_MEMBERSHIPS,

--- a/client/app/bundles/Events/components/Member.jsx
+++ b/client/app/bundles/Events/components/Member.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 
-import { membersPath } from '../utils/Pathnames';
+import { membersPath, groupPath } from '../utils/Pathnames';
 
 class Member extends Component {
   emailAddressLink() {
@@ -44,6 +44,16 @@ class Member extends Component {
     return <input type='checkbox' disabled={email ? false : true} onChange={this.handleChange.bind(this)}/>
   }
 
+  groupColumn() {
+    const {groups} = this.props;
+    if (groups.length && this.props.showGroupName){
+      return <td>{groups.map(group => {
+        const { id, name } = group;
+        return <Link className='group-list' to={`${groupPath(id)}`} key={id} >{name}</Link>
+      })}</td>
+    }
+  }
+
   render() {
     const { member, role, id } = this.props;
 
@@ -59,6 +69,7 @@ class Member extends Component {
         </td>
         <td>{member['primary-phone-number']}</td>
         <td>{this.localityAndRegion()}</td>
+        {this.groupColumn()}
         <td>{role}</td>
         <td>{this.emailAddressLink()}</td>
       </tr>

--- a/client/app/bundles/Events/components/Member.jsx
+++ b/client/app/bundles/Events/components/Member.jsx
@@ -49,7 +49,7 @@ class Member extends Component {
     if (groups.length && this.props.showGroupName){
       return <td>{groups.map(group => {
         const { id, name } = group;
-        return <Link className='group-list' to={`${groupPath(id)}`} key={id} >{name}</Link>
+        return <Link className='group-list' to={`${groupPath(id)}/dashboard`} key={id} >{name}</Link>
       })}</td>
     }
   }

--- a/client/app/bundles/Events/components/Member.jsx
+++ b/client/app/bundles/Events/components/Member.jsx
@@ -1,20 +1,17 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 
 import { membersPath } from '../utils/Pathnames';
 
-const Member = (props) => {
-  const { member } = props;
-  if(!member) { return null }
-
-  const emailAddressLink = () => {
-    const email = member['primary-email-address']
+class Member extends Component {
+  emailAddressLink() {
+    const email = this.props.member['primary-email-address']
     if (email)
-      return <a href={`mailto:'${email}'`} className='fa fa-envelope-o'/>
+      return <a href={`mailto:${email}`} className='fa fa-envelope-o'/>
   }
 
-  const localityAndRegion = () => {
-    const address = member['primary-personal-address']
+  localityAndRegion() {
+    const address = this.props.member['primary-personal-address']
     if (address) {
       if (address['locality'] && address['region']) {
         return <span>{address['locality']}, {address['region']}</span>
@@ -32,19 +29,41 @@ const Member = (props) => {
     return <span></span>
   }
 
-  return(
-    <tr>
-      <td>
-        <Link to={`${membersPath()}/${props.id}`}>
-          {member['given-name']} {member['family-name']}
-        </Link>
-      </td>
-      <td>{member['primary-phone-number']}</td>
-      <td>{ localityAndRegion() }</td>
-      <td>{props.role}</td>
-      <td>{ emailAddressLink() }</td>
-    </tr>
-  )
+  handleChange(ev) {
+    const { member, onCheckboxChecked, onCheckboxUnChecked } = this.props;
+    const email = member['primary-email-address'];
+
+    if(ev.target.checked && email)
+      onCheckboxChecked(email);
+    else
+      onCheckboxUnChecked(email)
+  }
+
+  showEmailCheckbox() {
+    const email = this.props.member['primary-email-address'];
+    return <input type='checkbox' disabled={email ? false : true} onChange={this.handleChange.bind(this)}/>
+  }
+
+  render() {
+    const { member, role, id } = this.props;
+
+    if(!member) { return null }
+
+    return(
+      <tr>
+        <td>{this.showEmailCheckbox()}</td>
+        <td>
+          <Link to={`${membersPath()}/${id}`}>
+            {member['given-name']} {member['family-name']}
+          </Link>
+        </td>
+        <td>{member['primary-phone-number']}</td>
+        <td>{this.localityAndRegion()}</td>
+        <td>{role}</td>
+        <td>{this.emailAddressLink()}</td>
+      </tr>
+    );
+  }
 }
 
 export default Member;

--- a/client/app/bundles/Events/components/Members.jsx
+++ b/client/app/bundles/Events/components/Members.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import queryString from 'query-string';
 import { connect } from 'react-redux';
+import _ from 'lodash';
 
 import Member from './Member';
 import MembersFilter from './MembersFilter';
@@ -15,6 +16,7 @@ class Members extends Component {
 
     this.filterMembers = this.filterMembers.bind(this);
     this.renderMembers = this.renderMembers.bind(this);
+    this.state = { emails: [] };
   }
 
   componentWillMount() {
@@ -46,8 +48,30 @@ class Members extends Component {
       return <Member key={person.id} id={person.id}
         member={person.attributes}
         role={membership.attributes.role}
+        onCheckboxChecked={this.addMemberEmail.bind(this)}
+        onCheckboxUnChecked={this.removeMemberEmail.bind(this)}
       />
     })
+  }
+
+  addMemberEmail(email) {
+    const emails = this.state.emails.concat(email);
+    this.setState({ emails });
+  }
+
+  removeMemberEmail(memberEmail) {
+    const emails = _.filter(this.state.emails, (email) => (email !== memberEmail));
+    this.setState({ emails });
+  }
+
+  generateEmailsLink() {
+    const { emails } = this.state;
+    if (emails.length)
+      return (
+        <a href={`mailto:${emails.join(',')}`} className='fa fa-envelope-o'/>
+      );
+    else
+      return (<i className='fa fa-envelope-o'/>);
   }
 
   render() {
@@ -66,7 +90,8 @@ class Members extends Component {
         <table className='table'>
           <thead>
             <tr>
-              <SortableHeader title='Name' sortBy='name' style={{ width: '30%'}} />
+              <th style={{ width: '5%'}}>{this.generateEmailsLink()}</th>
+              <SortableHeader title='Name' sortBy='name' style={{ width: '25%'}} />
               <th style={{ width: '15%'}}>Phone</th>
               <th style={{ width: '30%'}}>Location</th>
               <SortableHeader title='Role' sortBy='role' style={{ width: '20%'}} />

--- a/client/app/bundles/Events/components/Members.jsx
+++ b/client/app/bundles/Events/components/Members.jsx
@@ -47,9 +47,11 @@ class Members extends Component {
       const person = membership.attributes.person.data;
       return <Member key={person.id} id={person.id}
         member={person.attributes}
+        groups={person.relationships.groups.data}
         role={membership.attributes.role}
         onCheckboxChecked={this.addMemberEmail.bind(this)}
         onCheckboxUnChecked={this.removeMemberEmail.bind(this)}
+        showGroupName={this.props.showGroupName}
       />
     })
   }
@@ -74,6 +76,21 @@ class Members extends Component {
       return (<i className='fa fa-envelope-o'/>);
   }
 
+  groupColumn() {
+    if (this.props.showGroupName)
+      return <th style={{ width: '25%'}}>Group Name</th>
+  }
+
+  locationColumn() {
+    const width = this.props.showGroupName ? '10%' : '30%'
+    return <th style={{ width: `${width}`}}>Location</th>
+  }
+
+  phoneColumn() {
+    const width = this.props.showGroupName ? '10%' : '15%'
+    return <th style={{ width: `${width}`}}>Phone</th>
+  }
+
   render() {
     const { search } = this.props.location;
     const { filter } = queryString.parse(search);
@@ -92,8 +109,9 @@ class Members extends Component {
             <tr>
               <th style={{ width: '5%'}}>{this.generateEmailsLink()}</th>
               <SortableHeader title='Name' sortBy='name' style={{ width: '25%'}} />
-              <th style={{ width: '15%'}}>Phone</th>
-              <th style={{ width: '30%'}}>Location</th>
+              { this.phoneColumn() }
+              { this.locationColumn() }
+              { this.groupColumn() }
               <SortableHeader title='Role' sortBy='role' style={{ width: '20%'}} />
               <th style={{ width: '5%'}}></th>
             </tr>

--- a/client/app/bundles/Events/containers/Members.jsx
+++ b/client/app/bundles/Events/containers/Members.jsx
@@ -19,7 +19,9 @@ class Members extends Component {
         <br />
         <Nav activeTab='members'/>
 
-        <GroupMembers location={this.props.location} history={this.props.history} />
+        <GroupMembers location={this.props.location} history={this.props.history}
+          showGroupName={true}
+        />
       </div>
     );
   }

--- a/client/app/bundles/Events/utils/Pathnames.jsx
+++ b/client/app/bundles/Events/utils/Pathnames.jsx
@@ -1,5 +1,6 @@
 export const affiliatesPath = (id = null) => (`/groups/${id || groupId()}/affiliates`);
 export const membersPath = () => (`/groups/${groupId()}/members`);
+export const membershipPath = () => (`/groups/${groupId()}/memberships`);
 export const eventsPath = () => (`/groups/${groupId()}/events`);
 export const attendancesPath = (eventId) => (`/groups/${groupId()}/events/${eventId}/attendances`);
 export const groupsPath = () => (`/groups/${groupId()}/dashboard`)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
     resources :members do
       resources :events
     end
+    resources :memberships, only: [:index]
 
     resources :affiliates
 
@@ -85,9 +86,7 @@ Rails.application.routes.draw do
   end
 
   resources :dashboard, only: [:index]
-  resources :memberships, only: [:index]
 
-  resources :memberships, only: [:index]
 
   resources :profile, only: [:index]
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170601210713) do
+ActiveRecord::Schema.define(version: 20170606220214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,13 @@ ActiveRecord::Schema.define(version: 20170601210713) do
     t.integer "group_id"
     t.index ["advocacy_campaign_id"], name: "index_advocacy_campaigns_groups_on_advocacy_campaign_id", using: :btree
     t.index ["group_id"], name: "index_advocacy_campaigns_groups_on_group_id", using: :btree
+  end
+
+  create_table "affiliations", force: :cascade do |t|
+    t.integer  "group_id"
+    t.integer  "affiliate_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "answers", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,4 +22,4 @@ Membership.create(person: national_organizer, group: group, role: 'national_orga
 
 group.sync_with_action_network
 
-affiliate = Group.create(name: 'Affiliate Group', an_api_key: 'fake_api_key', creator: organizer)
+affiliate = Group.create(name: 'Affiliate Group', an_api_key: '7697d3813267b9ea9550648064dbc90b', creator: organizer)

--- a/test/controllers/attendances_controller_test.rb
+++ b/test/controllers/attendances_controller_test.rb
@@ -5,7 +5,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     @event = events(:test)
-    @group = groups(:one)
+    @group = groups(:test)
   end
 
   test 'require authentication' do
@@ -68,7 +68,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
     new_attendee.save
 
     post group_event_attendances_url(
-      group_id: groups(:one).id,
+      group_id: groups(:test).id,
       event_id: event.id,
       params: {
         attendance: {
@@ -94,7 +94,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
     memberships_count_before = Membership.count
 
     post group_event_attendances_url(
-      group_id: groups(:one).id,
+      group_id: groups(:test).id,
       event_id: event.id,
       params: {
         attendance: {
@@ -117,7 +117,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference 'Person.count', 1 do
       post group_event_attendances_url(
-        group_id: groups(:one).id,
+        group_id: groups(:test).id,
         event_id: event.id,
         params: {
           attendance: {

--- a/test/controllers/memberships_controller_test.rb
+++ b/test/controllers/memberships_controller_test.rb
@@ -7,13 +7,12 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
     person = people(:organizer)
     sign_in person
 
-    get memberships_url, as: :json
+    get group_memberships_url(group_id: groups(:test).id), as: :json
     assert_response :success
     json = JSON.parse(response.body)
 
     assert_equal person.groups.first.members.count, json['memberships']['data'].count
     response_members_ids = json['memberships']['data'].map { |m| m['id'].to_i }
-    byebug
     assert_includes response_members_ids, person.groups.first.memberships.first.id
   end
 
@@ -21,7 +20,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
     person = people(:organizer)
     sign_in person
 
-    get memberships_url(filter: 'admin'), as: :json
+    get group_memberships_url(group_id: groups(:test).id, filter: 'admin'), as: :json
     assert_response :success
     json = JSON.parse(response.body)
 

--- a/test/controllers/memberships_controller_test.rb
+++ b/test/controllers/memberships_controller_test.rb
@@ -13,6 +13,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal person.groups.first.members.count, json['memberships']['data'].count
     response_members_ids = json['memberships']['data'].map { |m| m['id'].to_i }
+    byebug
     assert_includes response_members_ids, person.groups.first.memberships.first.id
   end
 


### PR DESCRIPTION
related to #262. 
1) The group link is pointing to the public group page because of a member may also be a member of a group for which the nat organizer has no permissions. We can change this behavior.
2) Right now we are always showing the 'Group name' column because we need the  groups relations to know if we should show or hide that column.