### PR TITLE
Fixes double logo on password reset

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -39,6 +39,9 @@ body.logged_out {
         background-color: transparent;
         font-weight: normal;
       }
+      #error_explanation {
+        display: none;
+      }
 
       .action input[type="submit"] {
         font-size: 1.3em;


### PR DESCRIPTION
Fixes #379 

It looked like we were surfacing errors in multiple places on the login page. So I am suppressing a particular error that was being shown multiple times. The h2 selector was being overwritten by line 26 of active_admin.scss

Would encourage use of class level CSS over element targeting to prevent funky issues like this in the future.

Before:
![image](https://user-images.githubusercontent.com/13178670/32149182-baffeab0-bcbd-11e7-96e9-f27bfc9eaa4b.png)

After:
![image](https://user-images.githubusercontent.com/13178670/32149161-a0e0d086-bcbd-11e7-8418-3bb49a56abcc.png)
