### PR TITLE
Add attendances back to AN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 addons:
   postgresql: "9.5"
 env:
-  - TRAVIS_NODE_VERSION="7.7.3"
+  - TRAVIS_NODE_VERSION="6.9.0"
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install && cd client && npm install && npm run build:test

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -75,8 +75,7 @@ class AttendancesController < ApplicationController
 
   def attendance_params
     attrs = params.permit(:attended)
-
-    return attrs unless attrs.empty?
+    return attrs.merge(synced: false) unless attrs.empty?
 
     { attended: nil } #NOTE Axios ommits the params if its value is nil.
   end

--- a/app/models/api/action_network/attendances.rb
+++ b/app/models/api/action_network/attendances.rb
@@ -20,7 +20,7 @@ module Api::ActionNetwork::Attendances
 
     logger.info "Api::ActionNetwork::Attendances#import! from #{next_uri}"
 
-    #::Attendance.transaction do  
+    #::Attendance.transaction do
       while next_uri
         attendances, next_uri = request_resources_from_action_network(next_uri, group)
 

--- a/app/models/api/action_network/event.rb
+++ b/app/models/api/action_network/event.rb
@@ -1,0 +1,17 @@
+module Api::ActionNetwork::Event
+  extend Api::ActionNetwork::Export
+
+  def self.export!(event, group, save_if_error=true)
+    event_id = event.identifier_id('action_network')
+    export_uri = "https://actionnetwork.org/api/v2/events"
+    export_single_resource(event, group, export_uri, save_if_error)
+  end
+
+  def self.representer_class
+    Api::ActionNetwork::Export::EventRepresenter
+  end
+
+  def self.resource
+    'event'
+  end
+end

--- a/app/models/api/action_network/events.rb
+++ b/app/models/api/action_network/events.rb
@@ -12,16 +12,17 @@ module Api::ActionNetwork::Events
     synced_at = group.synced_at ? group.synced_at - 1.week : nil
     next_uri = first_uri(synced_at: synced_at)
 
-    logger.info "Api::ActionNetwork::Events#import! from #{next_uri}"
-
     #Event.transaction do
       while next_uri
+
+        logger.info "info: Api::ActionNetwork::Events#import! from #{next_uri}"
+
         events, next_uri = request_resources_from_action_network(next_uri, group)
 
         existing_events, new_events = partition(events)
 
         new_count += new_events.size
-        
+
         existing_count += existing_count.size
         updated_count = update_resources(existing_events)
 
@@ -29,7 +30,7 @@ module Api::ActionNetwork::Events
 
         create new_events
       end
-      logger.debug "Api::ActionNetwork::Events#import! new: #{new_count} existing: #{existing_count} updated: #{updated_count}"
+      logger.debug "info: Api::ActionNetwork::Events#import! new: #{new_count} existing: #{existing_count} updated: #{updated_count}"
     #end
 
     {
@@ -91,4 +92,5 @@ module Api::ActionNetwork::Events
   def self.errors_count=(errors)
     @errors_count = errors
   end
+
 end

--- a/app/models/api/action_network/export.rb
+++ b/app/models/api/action_network/export.rb
@@ -1,11 +1,11 @@
 module Api::ActionNetwork::Export
-  def export_single_resource(element, group, uri)
+  def export_single_resource(element, group, uri, save_if_error=true)
     client = representer_class.new(element)
-    client.post(uri: uri, as: 'application/json') do |request|
-      request['OSDI-API-TOKEN'] = group.an_api_key
+    client.post(uri: uri, as: 'application/json') do
+      |request| request['OSDI-API-TOKEN'] = group.an_api_key
     end
   rescue => e
     #NOTE: client#post tries to save the post response, which may fail.
-    element.save
+    element.save if save_if_error
   end
 end

--- a/app/models/api/action_network/remote_attendance.rb
+++ b/app/models/api/action_network/remote_attendance.rb
@@ -1,0 +1,18 @@
+module Api::ActionNetwork::RemoteAttendance
+  extend Api::ActionNetwork::Export
+
+  class << self
+    def export!(attendance, group, event_identifier)
+      export_uri = "https://actionnetwork.org/api/v2/events/#{event_identifier}/attendances"
+      export_single_resource(attendance, group, export_uri, false)
+    end
+
+    def representer_class
+      Api::ActionNetwork::Export::AttendanceRepresenter
+    end
+
+    def resource
+      'attendance'
+    end
+  end
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -48,4 +48,25 @@ class Attendance < ApplicationRecord
       event[:missed] = (grouped_by_attended[false] || []).size
     end.keys
   end
+
+  def send_to_att_event_action_network
+    return if attended.nil?
+    attendance = remote_attendance_exported
+    attendance.export(attendance.event.group)
+  end
+
+  private
+
+  def remote_attendance_exported
+    attended ? send_to_action_network_att_event : send_to_action_network_no_att_event
+  end
+
+  def send_to_action_network_att_event
+    event.attendance_event&.export_attendace(self)
+  end
+
+  def send_to_action_network_no_att_event
+    event.no_attendance_event&.export_attendace(self)
+  end
+
 end

--- a/app/models/attendance_event.rb
+++ b/app/models/attendance_event.rb
@@ -1,0 +1,9 @@
+class AttendanceEvent < RemoteEvent
+  include HasAttendanceEvent
+
+  def self.att_event_name(event_title)
+    "#{event_title}_ATT"
+  end
+
+end
+

--- a/app/models/concerns/has_attendance_event.rb
+++ b/app/models/concerns/has_attendance_event.rb
@@ -1,0 +1,67 @@
+module HasAttendanceEvent
+  extend ActiveSupport::Concern
+  include Api::Identifiers
+
+  included do
+    belongs_to :event
+
+    def self.create_and_sync(event)
+      event_dup = event.dup
+      event_dup.origin_system = 'Affinity'
+      event_dup.title = att_event_name(event.title)
+      event_dup.name = att_event_name(event.title)
+      event_dup.identifiers = []
+      event_dup = Api::ActionNetwork::Event.export!(event_dup, event.group, false)
+      create_att_event(event_dup, event) if event_dup
+    end
+
+    def self.create_att_event(event_dup, event)
+      create(name: event_dup.title,
+             uid: event_dup.identifier('action_network'),
+             identifiers: event_dup.identifiers, event_id: event.id)
+    end
+  end
+
+
+  def export_attendace(attendance)
+    group = attendance.event.group
+    attendance_dup = attendance.dup
+    event_identifier = identifier_id('action_network')
+
+    att_event_identifier = remote_att_event_identifier(attendance)
+    remote_identifier = rename_remote_identifier(att_event_identifier)
+
+    attendance_dup.identifiers = []
+    attendance_dup.identifiers << remote_identifier if remote_identifier
+
+    attendance_dup = Api::ActionNetwork::RemoteAttendance.export!(attendance_dup,
+                                                                  group, event_identifier)
+
+    attendance = save_remote_att_event_identifier(attendance, attendance_dup)
+
+    attendance
+  end
+
+  private
+
+  def rename_remote_identifier(att_event_identifier)
+    att_event_identifier&.gsub(attendance_identifier_prefix, 'action_network')
+  end
+
+  def remote_att_event_identifier(attendance)
+    attendance.identifier(attendance_identifier_prefix)
+  end
+
+  def attendance_identifier_prefix
+    is_a?(AttendanceEvent) ? 'att_identifier' : 'no_att_identifier'
+  end
+
+  def save_remote_att_event_identifier(attendance, attendance_dup)
+    identifier_name = attendance_identifier_prefix
+    identifier_name_value = attendance_dup.identifier_id('action_network')
+    remote_identifier = "#{identifier_name}:#{identifier_name_value}"
+    return attendance if attendance.identifier?(remote_identifier)
+    attendance.add_identifier(identifier_name, identifier_name_value)
+    attendance
+  end
+end

--- a/app/models/concerns/has_remote_event.rb
+++ b/app/models/concerns/has_remote_event.rb
@@ -1,0 +1,14 @@
+module HasRemoteEvent
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :create_remote_events
+  end
+
+  private
+
+  def create_remote_events
+    AttendanceEvent.create_and_sync(self)
+    NoAttendanceEvent.create_and_sync(self)
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,11 +1,10 @@
 class Event < ApplicationRecord
   include Api::Identifiers
   include ArelHelpers::ArelTable
-  
+  include HasRemoteEvent
+
   has_paper_trail ignore: [:created_at, :updated_at]
   acts_as_taggable
-
-  default_scope { where.not(status: 'cancelled') }
 
   attr_accessor :attended_count
   attr_accessor :rsvp_count
@@ -26,6 +25,8 @@ class Event < ApplicationRecord
   has_many :reminders, dependent: :destroy
   has_and_belongs_to_many :groups
   has_many :facebook_events, dependent: :destroy
+  has_one :attendance_event, dependent: :destroy
+  has_one :no_attendance_event, dependent: :destroy
 
   #My suspicion is that it's better to do this in sql and not sore all this in memory
   def self.add_attendance_counts(events)
@@ -57,4 +58,5 @@ class Event < ApplicationRecord
   def to_activity_json
     as_json(only: [:title, :id, :created_at, :updated_at], include: { group: { only:[:name] } })
   end
+
 end

--- a/app/models/no_attendance_event.rb
+++ b/app/models/no_attendance_event.rb
@@ -1,0 +1,8 @@
+class NoAttendanceEvent < RemoteEvent
+  include HasAttendanceEvent
+
+  def self.att_event_name(event_title)
+    "#{event_title}_NO_ATT"
+  end
+end
+

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,8 +1,10 @@
 class PhoneNumber < ApplicationRecord
   include ArelHelpers::ArelTable
   belongs_to :person
-
-  validates :number, :presence => true, format: { with:  /\A(\((\d){3}\)\s|(\+1-)?(\d){3}-)(\d){3}-(\d){4}|(\d){10}\z/, message: 'Only numbers format are allowed' }
+  PHONE_FORMAT = /\A(\((\d){3}\)\s|(\+1-)?(\d){3}-)(\d){3}-(\d){4}|(\d){10}\z/
+  validates :number, :presence => true,
+            format: { with:  PHONE_FORMAT,
+            message: 'Only numbers format are allowed' }
   validates_uniqueness_of :number, scope: :person_id
 
   scope :primary, -> { where(primary: true) }

--- a/app/representers/api/action_network/export/attendance_representer.rb
+++ b/app/representers/api/action_network/export/attendance_representer.rb
@@ -6,14 +6,11 @@ class Api::ActionNetwork::Export::AttendanceRepresenter < Roar::Decorator
   include Roar::JSON::HAL
 
   property :identifiers
+  property :status
 
   link 'osdi:person' do
     person_id = represented.person.identifier_id('action_network')
     "https://actionnetwork.org/api/v2/people/#{person_id}"
   end
 
-  link 'osdi:event' do
-    event_id = represented.event.identifier_id('action_network')
-    "https://actionnetwork.org/api/v2/events/#{event_id}"
-  end
 end

--- a/app/representers/api/action_network/export/event_representer.rb
+++ b/app/representers/api/action_network/export/event_representer.rb
@@ -1,0 +1,16 @@
+require 'roar/client'
+require 'roar/json/hal'
+
+class Api::ActionNetwork::Export::EventRepresenter < Roar::Decorator
+  include Roar::Client
+  include Roar::JSON::HAL
+
+  property :identifiers
+  property :title
+  property :origin_system
+
+  link 'osdi:organizer' do
+    person_id = represented.creator&.identifier_id('action_network')
+    "https://actionnetwork.org/api/v2/people/#{person_id}" if person_id
+  end
+end

--- a/db/migrate/20171205142709_add_identifiers_to_remote_event.rb
+++ b/db/migrate/20171205142709_add_identifiers_to_remote_event.rb
@@ -1,0 +1,5 @@
+class AddIdentifiersToRemoteEvent < ActiveRecord::Migration[5.0]
+  def change
+    add_column :remote_events, :identifiers, :text, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623203342) do
+ActiveRecord::Schema.define(version: 20171205142709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -660,6 +660,7 @@ ActiveRecord::Schema.define(version: 20170623203342) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.integer  "event_id"
+    t.text     "identifiers", default: [], array: true
   end
 
   create_table "responses", force: :cascade do |t|

--- a/lib/tasks/action_network_syncer.rake
+++ b/lib/tasks/action_network_syncer.rake
@@ -15,7 +15,10 @@ namespace :action_network_syncer do
         Rails.logger.debug "### EXPORTING #{group.name} MEMBERS ###"
         group.members.unsynced.each { |member| member.export(group) }
         Rails.logger.debug "### EXPORTING #{group.name} ATTENDANCES ###"
-        group.attendances.unsynced.each { |attendance| attendance.export(group) }
+        group.attendances.unsynced.each do |attendance|
+          attendance.export(group)
+          attendance.send_to_att_event_action_network
+        end
       end
     end
     Rails.logger.debug '### EXPORT FINISHED ###'

--- a/test/controllers/api/v1/attendances_controller_test.rb
+++ b/test/controllers/api/v1/attendances_controller_test.rb
@@ -13,7 +13,7 @@ class Api::V1::AttendancesControllerTest < ActionController::TestCase
 
     assert_not attendance.attended
 
-    set_attendance_status(event.id, attendance.id, new_attendance_status)
+    set_attendance_status(event, attendance.id, new_attendance_status)
     assert_response :unauthorized
 
     token = Minitest::Mock.new
@@ -23,14 +23,14 @@ class Api::V1::AttendancesControllerTest < ActionController::TestCase
 
     @controller.stub(:doorkeeper_token, token) do
 
-      set_attendance_status(event.id, attendance.id, new_attendance_status)
+      set_attendance_status(event, attendance.id, new_attendance_status)
       assert_response :success
 
       attendance.reload
       assert attendance.attended, 'Sets the attendance to true.'
 
       new_attendance_status = false
-      set_attendance_status(event.id, attendance.id, new_attendance_status)
+      set_attendance_status(event, attendance.id, new_attendance_status)
 
       attendance.reload
       assert_not attendance.attended, 'Sets the attendance to true.'
@@ -40,14 +40,18 @@ class Api::V1::AttendancesControllerTest < ActionController::TestCase
       assert_equal json['attributes']['status'], attendance.status
 
       new_attendance_status = nil
-      set_attendance_status(event.id, attendance.id, new_attendance_status)
+      set_attendance_status(event, attendance.id, new_attendance_status)
 
       attendance.reload
       assert_nil attendance.attended, 'Sets the attendance to nil.'
     end
   end
 
-  def set_attendance_status(event_id, attendance_id, status)
-    put(:update, params: { event_id: event_id, id: attendance_id, attended: status })
+  def set_attendance_status(event, attendance_id, status)
+    put(:update, params: { event_id: event.id, id: attendance_id, attended: status })
+  end
+
+  def url(event_id)
+    "https://actionnetwork.org/api/v2/events/#{event_id}/attendances"
   end
 end

--- a/test/controllers/attendances_controller_test.rb
+++ b/test/controllers/attendances_controller_test.rb
@@ -41,6 +41,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
     assert attendance.attended, 'Sets the attendance to true.'
 
     new_attendance_status = false
+
     set_attendance_status(group.id, event.id, attendance.id, new_attendance_status)
 
     attendance.reload
@@ -51,6 +52,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
     assert_equal json['attributes']['status'], attendance.status
 
     new_attendance_status = nil
+
     set_attendance_status(group.id, event.id, attendance.id, new_attendance_status)
 
     attendance.reload
@@ -113,7 +115,7 @@ class AttendancesControllerTest < ActionDispatch::IntegrationTest
     sign_in current_user
 
     email = 'test@test.com'
-    phone = rand(1_000_000).to_s
+    phone = '(123) 456-7890'
 
     assert_difference 'Person.count', 1 do
       post group_event_attendances_url(

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -82,6 +82,7 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
     sign_in current_user
 
     remote_event_count_before = RemoteEvent.count
+    facebook_event_count_before  = FacebookEvent.count
 
     post group_imports_url(
       group_id: group.id,
@@ -94,7 +95,7 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal remote_event_count_before + 1, RemoteEvent.count
-    assert_equal remote_event_count_before + 1, FacebookEvent.count
+    assert_equal facebook_event_count_before + 1, FacebookEvent.count
   end
 
   test 'get #attendances' do

--- a/test/fixtures/attendances.yml
+++ b/test/fixtures/attendances.yml
@@ -19,6 +19,8 @@ two:
   comment: MyString
   person_id: 2
   event_id: 1
+  identifiers: ['action_network:8b4a7a09-51ef-40dc-9120-48b8e3e3c7e7', 'advocacycommons:2']
+  synced: false
 
 admin:
   id: 3
@@ -46,4 +48,15 @@ organizer:
   status: accepted
   attended: false
   person_id: 6
+  event_id: 3
+
+seven:
+  id: 7
+  origin_system: MyString
+  identifiers: ['action_network:6216ce97-d826-46fc-a670-a3c3c0d5783f', 'advocacycommons:7']
+  action_date: 2016-12-21 23:40:11
+  status: accepted
+  attended: true
+  comment: MyString
+  person_id: 2
   event_id: 3

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -29,7 +29,7 @@ one:
   creator_id: 1
   organizer_id: 1
   modified_by_id: 1
-  identifiers: ['advocacycommons:1']
+  identifiers: ['action_network:bc82a374-fba9-4f47-8e6b-96fdd8350ca2', 'advocacycommons:1']
 
 two:
   id: 2
@@ -64,7 +64,7 @@ two:
 
 test:
   id: 3
-  origin_system: MyString
+  origin_system: Action Network
   name: MyString
   title: Event Title
   description: MyString
@@ -91,4 +91,4 @@ test:
   creator_id: 5
   organizer_id: 6
   modified_by_id: 4
-  identifiers: ['action_network:1efc3644-af25-4253-90b8-a0baf1ddbd1e', 'advocacycommons:2']
+  identifiers: ['action_network:9bbc8d08-a921-4b19-aadf-6cd8a3d09461', 'advocacycommons:3']

--- a/test/fixtures/files/attendances/no_attendance.json
+++ b/test/fixtures/files/attendances/no_attendance.json
@@ -1,0 +1,38 @@
+{
+  "identifiers": [
+    "action_network:f0266b45-1ff1-4680-8221-5f9e1f3046ec"
+  ],
+  "created_date": "2017-12-06T11:13:01Z",
+  "modified_date": "2017-12-11T19:12:36Z",
+  "status": "accepted",
+  "action_network:person_id": "af902ad6-7d15-4bde-a096-92d581d442af",
+  "action_network:event_id": "6a9454b5-56d5-49ad-ae10-cc2d9506dd8b",
+  "action_network:referrer_data": {
+    "source": "none",
+    "referrer": "affinity-test",
+    "website": "api"
+  },
+  "_links": {
+    "self": {
+      "href": "https://actionnetwork.org/api/v2/events/6a9454b5-56d5-49ad-ae10-cc2d9506dd8b/attendances/f0266b45-1ff1-4680-8221-5f9e1f3046ec"
+    },
+    "osdi:event": {
+      "href": "https://actionnetwork.org/api/v2/events/6a9454b5-56d5-49ad-ae10-cc2d9506dd8b"
+    },
+    "curies": [
+      {
+        "name": "osdi",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      },
+      {
+        "name": "action_network",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      }
+    ],
+    "osdi:person": {
+      "href": "https://actionnetwork.org/api/v2/people/af902ad6-7d15-4bde-a096-92d581d442af"
+    }
+  }
+}

--- a/test/fixtures/files/attendances/original_attendance.json
+++ b/test/fixtures/files/attendances/original_attendance.json
@@ -1,0 +1,40 @@
+{
+  "identifiers": [
+    "action_network:6216ce97-d826-46fc-a670-a3c3c0d5783f",
+    "att_identifier:759e3729-c780-4e68-8d5f-12ff739c719e"
+    "no_att_identifier:f0266b45-1ff1-4680-8221-5f9e1f3046ec"
+  ],
+  "created_date": "2017-12-07T15:59:30Z",
+  "modified_date": "2017-12-07T15:59:30Z",
+  "status": "accepted",
+  "action_network:person_id": "b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184",
+  "action_network:event_id": "9bbc8d08-a921-4b19-aadf-6cd8a3d09461",
+  "action_network:referrer_data": {
+    "source": "none",
+    "referrer": "affinity-test",
+    "website": "api"
+  },
+  "_links": {
+    "self": {
+      "href": "https://actionnetwork.org/api/v2/events/9bbc8d08-a921-4b19-aadf-6cd8a3d09461/attendances/6216ce97-d826-46fc-a670-a3c3c0d5783f"
+    },
+    "osdi:event": {
+      "href": "https://actionnetwork.org/api/v2/events/9bbc8d08-a921-4b19-aadf-6cd8a3d09461"
+    },
+    "curies": [
+      {
+        "name": "osdi",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      },
+      {
+        "name": "action_network",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      }
+    ],
+    "osdi:person": {
+      "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+    }
+  }
+}

--- a/test/fixtures/files/attendances/yes_attendance.json
+++ b/test/fixtures/files/attendances/yes_attendance.json
@@ -1,0 +1,38 @@
+{
+  "identifiers": [
+    "action_network:759e3729-c780-4e68-8d5f-12ff739c719e"
+  ],
+  "created_date": "2017-12-07T15:59:30Z",
+  "modified_date": "2017-12-07T15:59:30Z",
+  "status": "accepted",
+  "action_network:person_id": "b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184",
+  "action_network:event_id": "cc5501be-f92c-4387-9827-63d2eee65e5b",
+  "action_network:referrer_data": {
+    "source": "none",
+    "referrer": "affinity-test",
+    "website": "api"
+  },
+  "_links": {
+    "self": {
+      "href": "https://actionnetwork.org/api/v2/events/cc5501be-f92c-4387-9827-63d2eee65e5b/attendances/759e3729-c780-4e68-8d5f-12ff739c719e"
+    },
+    "osdi:event": {
+      "href": "https://actionnetwork.org/api/v2/events/cc5501be-f92c-4387-9827-63d2eee65e5b"
+    },
+    "curies": [
+      {
+        "name": "osdi",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      },
+      {
+        "name": "action_network",
+        "href": "https://actionnetwork.org/docs/v2/{rel}",
+        "templated": true
+      }
+    ],
+    "osdi:person": {
+      "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+    }
+  }
+}

--- a/test/fixtures/files/events.json
+++ b/test/fixtures/files/events.json
@@ -3,7 +3,7 @@
     "page": 1,
     "_links": {
         "next": {
-            "href": "https://actionnetwork.org/api/v2/events?page=2"
+            "href": "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'&page=2"
         },
         "osdi:forms": [
             {
@@ -31,7 +31,7 @@
                     "action_network:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
                     "foreign_system:1"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T21:04:31Z",
                 "modified_date": "2014-03-20T21:04:31Z",
                 "name": "March 14th Rally",
@@ -152,7 +152,7 @@
                 "identifiers": [
                     "action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2014-03-20T20:44:13Z",
                 "title": "House Party for Progress",
@@ -268,7 +268,7 @@
                 "identifiers": [
                     "action_network:a3c724db-2799-49a6-970a-7c3c0844645d"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2015-04-20T20:19:09Z",
                 "title": "Teach in",

--- a/test/fixtures/files/events/att_event.json
+++ b/test/fixtures/files/events/att_event.json
@@ -1,0 +1,214 @@
+{
+    "identifiers": [
+        "action_network:bb75d46b-3f86-4a39-9193-b9d5bd873eae"
+    ],
+    "created_date": "2017-12-06T11:06:37Z",
+    "description": "<p>description</p>",
+    "start_date": "2017-12-31T06:00:00Z",
+    "reminders": [
+        {
+            "method": "email",
+            "minutes": 1440
+        }
+    ],
+    "total_accepted": 7,
+    "action_network:sponsor": {
+        "title": "Affinity Test",
+        "browser_url": "https://actionnetwork.org/api/v2/groups/affinity-test"
+    },
+    "location": {
+        "venue": "Metropolitano",
+        "address_lines": [
+            "1601 NW 82 Avenue FLY (18760), "
+        ],
+        "locality": "Doral",
+        "region": "FL",
+        "postal_code": "33126",
+        "country": "US",
+        "location": {
+            "latitude": 25.788796734240996,
+            "longitude": -80.3285917910888,
+            "accuracy": "Rooftop"
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5"
+        },
+        "osdi:organizer": {
+            "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+        },
+        "osdi:creator": {
+            "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+        },
+        "curies": [
+            {
+                "name": "osdi",
+                "href": "https://actionnetwork.org/docs/v2/{rel}",
+                "templated": true
+            },
+            {
+                "name": "action_network",
+                "href": "https://actionnetwork.org/docs/v2/{rel}",
+                "templated": true
+            }
+        ],
+        "osdi:attendances": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5/attendances"
+        },
+        "record_attendance_helper": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5/attendances"
+        },
+        "osdi:record_attendance_helper": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5/attendances"
+        }
+    },
+    "modified_date": "2017-12-07T15:44:12Z",
+    "status": "confirmed",
+    "transparence": "opaque",
+    "visibility": "public",
+    "guests_can_invite_others": true,
+    "origin_system": "Affinity",
+    "title": "Original_ATT",
+    "name": "Original_ATT",
+    "instructions": "<h3>Instructions For Your Attendees</h3><div><div><div><ul><li></li></ul></div></div></div>",
+    "_embedded": {
+        "osdi:creator": {
+            "given_name": "Arnol",
+            "family_name": "Fontalvo",
+            "identifiers": [
+                "action_network:b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+            ],
+            "email_addresses": [
+                {
+                    "primary": true,
+                    "address": "arnol.fontalvo@koombea.com",
+                    "status": "subscribed"
+                }
+            ],
+            "postal_addresses": [
+                {
+                    "primary": true,
+                    "locality": "Barranquilla",
+                    "postal_code": "080010",
+                    "country": "US",
+                    "location": {
+                        "latitude": 10.9322,
+                        "longitude": -74.8071,
+                        "accuracy": "Approximate"
+                    }
+                }
+            ],
+            "_links": {
+                "self": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+                },
+                "osdi:signatures": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/signatures"
+                },
+                "osdi:submissions": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/submissions"
+                },
+                "osdi:donations": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/donations"
+                },
+                "curies": [
+                    {
+                        "name": "osdi",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    },
+                    {
+                        "name": "action_network",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    }
+                ],
+                "osdi:taggings": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/taggings"
+                },
+                "osdi:outreaches": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/outreaches"
+                },
+                "osdi:attendances": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/attendances"
+                }
+            },
+            "custom_fields": {},
+            "created_date": "2017-11-10T15:56:35Z",
+            "modified_date": "2017-11-30T16:22:47Z",
+            "languages_spoken": [
+                "en"
+            ]
+        },
+        "osdi:organizer": {
+            "given_name": "Arnol",
+            "family_name": "Fontalvo",
+            "identifiers": [
+                "action_network:b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+            ],
+            "email_addresses": [
+                {
+                    "primary": true,
+                    "address": "arnol.fontalvo@koombea.com",
+                    "status": "subscribed"
+                }
+            ],
+            "postal_addresses": [
+                {
+                    "primary": true,
+                    "locality": "Barranquilla",
+                    "postal_code": "080010",
+                    "country": "US",
+                    "location": {
+                        "latitude": 10.9322,
+                        "longitude": -74.8071,
+                        "accuracy": "Approximate"
+                    }
+                }
+            ],
+            "_links": {
+                "self": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+                },
+                "osdi:signatures": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/signatures"
+                },
+                "osdi:submissions": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/submissions"
+                },
+                "osdi:donations": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/donations"
+                },
+                "curies": [
+                    {
+                        "name": "osdi",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    },
+                    {
+                        "name": "action_network",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    }
+                ],
+                "osdi:taggings": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/taggings"
+                },
+                "osdi:outreaches": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/outreaches"
+                },
+                "osdi:attendances": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/attendances"
+                }
+            },
+            "custom_fields": {},
+            "created_date": "2017-11-10T15:56:35Z",
+            "modified_date": "2017-11-30T16:22:47Z",
+            "languages_spoken": [
+                "en"
+            ]
+        }
+    },
+    "action_network:hidden": false
+}

--- a/test/fixtures/files/events/no_att_event.json
+++ b/test/fixtures/files/events/no_att_event.json
@@ -1,0 +1,214 @@
+{
+    "identifiers": [
+        "action_network:4f11250f-4bdc-4358-b839-dac9d18cd8c8"
+    ],
+    "created_date": "2017-12-06T11:06:37Z",
+    "description": "<p>description</p>",
+    "start_date": "2017-12-31T06:00:00Z",
+    "reminders": [
+        {
+            "method": "email",
+            "minutes": 1440
+        }
+    ],
+    "total_accepted": 7,
+    "action_network:sponsor": {
+        "title": "Affinity Test",
+        "browser_url": "https://actionnetwork.org/api/v2/groups/affinity-test"
+    },
+    "location": {
+        "venue": "Metropolitano",
+        "address_lines": [
+            "1601 NW 82 Avenue FLY (18760), "
+        ],
+        "locality": "Doral",
+        "region": "FL",
+        "postal_code": "33126",
+        "country": "US",
+        "location": {
+            "latitude": 25.788796734240996,
+            "longitude": -80.3285917910888,
+            "accuracy": "Rooftop"
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5"
+        },
+        "osdi:organizer": {
+            "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+        },
+        "osdi:creator": {
+            "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+        },
+        "curies": [
+            {
+                "name": "osdi",
+                "href": "https://actionnetwork.org/docs/v2/{rel}",
+                "templated": true
+            },
+            {
+                "name": "action_network",
+                "href": "https://actionnetwork.org/docs/v2/{rel}",
+                "templated": true
+            }
+        ],
+        "osdi:attendances": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5/attendances"
+        },
+        "record_attendance_helper": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5/attendances"
+        },
+        "osdi:record_attendance_helper": {
+            "href": "https://actionnetwork.org/api/v2/events/3f556381-7c3b-40dc-92bc-034adc62bcd5/attendances"
+        }
+    },
+    "modified_date": "2017-12-07T15:44:12Z",
+    "status": "confirmed",
+    "transparence": "opaque",
+    "visibility": "public",
+    "guests_can_invite_others": true,
+    "origin_system": "Affinity",
+    "title": "Original_NO_ATT",
+    "name": "Original_NO_ATT",
+    "instructions": "<h3>Instructions For Your Attendees</h3><div><div><div><ul><li></li></ul></div></div></div>",
+    "_embedded": {
+        "osdi:creator": {
+            "given_name": "Arnol",
+            "family_name": "Fontalvo",
+            "identifiers": [
+                "action_network:b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+            ],
+            "email_addresses": [
+                {
+                    "primary": true,
+                    "address": "arnol.fontalvo@koombea.com",
+                    "status": "subscribed"
+                }
+            ],
+            "postal_addresses": [
+                {
+                    "primary": true,
+                    "locality": "Barranquilla",
+                    "postal_code": "080010",
+                    "country": "US",
+                    "location": {
+                        "latitude": 10.9322,
+                        "longitude": -74.8071,
+                        "accuracy": "Approximate"
+                    }
+                }
+            ],
+            "_links": {
+                "self": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+                },
+                "osdi:signatures": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/signatures"
+                },
+                "osdi:submissions": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/submissions"
+                },
+                "osdi:donations": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/donations"
+                },
+                "curies": [
+                    {
+                        "name": "osdi",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    },
+                    {
+                        "name": "action_network",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    }
+                ],
+                "osdi:taggings": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/taggings"
+                },
+                "osdi:outreaches": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/outreaches"
+                },
+                "osdi:attendances": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/attendances"
+                }
+            },
+            "custom_fields": {},
+            "created_date": "2017-11-10T15:56:35Z",
+            "modified_date": "2017-11-30T16:22:47Z",
+            "languages_spoken": [
+                "en"
+            ]
+        },
+        "osdi:organizer": {
+            "given_name": "Arnol",
+            "family_name": "Fontalvo",
+            "identifiers": [
+                "action_network:b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+            ],
+            "email_addresses": [
+                {
+                    "primary": true,
+                    "address": "arnol.fontalvo@koombea.com",
+                    "status": "subscribed"
+                }
+            ],
+            "postal_addresses": [
+                {
+                    "primary": true,
+                    "locality": "Barranquilla",
+                    "postal_code": "080010",
+                    "country": "US",
+                    "location": {
+                        "latitude": 10.9322,
+                        "longitude": -74.8071,
+                        "accuracy": "Approximate"
+                    }
+                }
+            ],
+            "_links": {
+                "self": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184"
+                },
+                "osdi:signatures": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/signatures"
+                },
+                "osdi:submissions": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/submissions"
+                },
+                "osdi:donations": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/donations"
+                },
+                "curies": [
+                    {
+                        "name": "osdi",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    },
+                    {
+                        "name": "action_network",
+                        "href": "https://actionnetwork.org/docs/v2/{rel}",
+                        "templated": true
+                    }
+                ],
+                "osdi:taggings": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/taggings"
+                },
+                "osdi:outreaches": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/outreaches"
+                },
+                "osdi:attendances": {
+                    "href": "https://actionnetwork.org/api/v2/people/b0b4a1cb-00fc-4677-8ce4-70d9ebbc6184/attendances"
+                }
+            },
+            "custom_fields": {},
+            "created_date": "2017-11-10T15:56:35Z",
+            "modified_date": "2017-11-30T16:22:47Z",
+            "languages_spoken": [
+                "en"
+            ]
+        }
+    },
+    "action_network:hidden": false
+}

--- a/test/fixtures/files/events2.json
+++ b/test/fixtures/files/events2.json
@@ -3,7 +3,7 @@
     "page": 1,
     "_links": {
         "next": {
-            "href": "https://actionnetwork.org/api/v2/events?page=2"
+            "href": "https://actionnetwork.org/api/v2/events?page=2&filter=origin_system eq 'Action Network'"
         },
         "osdi:forms": [
             {
@@ -31,7 +31,7 @@
                     "action_network:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3",
                     "foreign_system:1"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T21:04:31Z",
                 "modified_date": "2014-03-20T21:04:31Z",
                 "name": "March 16th Rally",
@@ -152,7 +152,7 @@
                 "identifiers": [
                     "action_network:1efc3644-af25-4253-90b8-a0baf12dbd1e"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2014-03-20T20:44:13Z",
                 "title": "House Party for Progress",
@@ -268,7 +268,7 @@
                 "identifiers": [
                     "action_network:a3c724db-2799-49a6-970a-7c3c0844645d"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T20:44:13Z",
                 "modified_date": "2015-04-20T20:19:09Z",
                 "title": "Teach in",

--- a/test/fixtures/files/events_page_2.json
+++ b/test/fixtures/files/events_page_2.json
@@ -1,9 +1,9 @@
 {
     "per_page": 25,
-    "page": 1,
+    "page": 2,
     "_links": {
         "previous": {
-            "href": "https://actionnetwork.org/api/v2/events?page=1"
+            "href": "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'&page=1"
         },
         "osdi:forms": [
             {
@@ -28,10 +28,9 @@
         "osdi:events": [
             {
                 "identifiers": [
-                    "action_network:d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bd4",
-                    "foreign_system:1"
+                    "action_network:a01e94bf-f132-41c1-a1be-358cc7757119"
                 ],
-                "origin_system": "OSDI Sample System",
+                "origin_system": "Action Network",
                 "created_date": "2014-03-20T21:04:31Z",
                 "modified_date": "2017-03-20T21:04:31Z",
                 "name": "March 15th Rally",

--- a/test/fixtures/remote_events.yml
+++ b/test/fixtures/remote_events.yml
@@ -16,3 +16,25 @@ not_associated:
   uid: "439761533049554"
   start_date: "2017-06-03 04:00:00"
   end_date: "2017-06-03 04:00:00"
+
+attendance_event:
+  id: 3
+  type: "AttendanceEvent"
+  name: "ATT Event"
+  event_id: 3
+  description: "Please join us for a night of dancing and communit..."
+  uid: "cc5501be-f92c-4387-9827-63d2eee65e5b"
+  start_date: "2017-12-07 04:00:00"
+  end_date: "2017-12-07 05:00:00"
+  identifiers: ['action_network:cc5501be-f92c-4387-9827-63d2eee65e5b', 'advocacycommons:3']
+
+no_attendance_event:
+  id: 4
+  type: "NoAttendanceEvent"
+  name: "NO_ATT Event"
+  event_id: 3
+  description: "Please join us for a night of dancing and communit..."
+  uid: "6a9454b5-56d5-49ad-ae10-cc2d9506dd8b"
+  start_date: "2017-12-07 04:00:00"
+  end_date: "2017-12-07 05:00:00"
+  identifiers: ['action_network:6a9454b5-56d5-49ad-ae10-cc2d9506dd8b', 'advocacycommons:4']

--- a/test/models/api/action_network/events_test.rb
+++ b/test/models/api/action_network/events_test.rb
@@ -4,13 +4,19 @@ class Api::ActionNetwork::EventsTest < ActiveSupport::TestCase
   test '.import!' do
     group = Group.first
 
-    stub_request(:get, 'https://actionnetwork.org/api/v2/events')
+    # first request. It should return another page in the next section
+    stub_request(:get, "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'")
       .with(headers: { 'OSDI-API-TOKEN' => group.an_api_key })
       .to_return(body: File.read(Rails.root.join('test', 'fixtures', 'files', 'events.json')))
 
-    stub_request(:get, 'https://actionnetwork.org/api/v2/events?page=2')
+
+    # # second request. It should not return another page in the next section
+    stub_request(:get, "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'&page=2")
       .with(headers: { 'OSDI-API-TOKEN' => group.an_api_key })
       .to_return(body: File.read(Rails.root.join('test', 'fixtures', 'files', 'events_page_2.json')))
+
+
+    stub_request(:post, 'https://actionnetwork.org/api/v2/events').to_return(status: 200)
 
     travel_to Time.zone.local(2001) do
       group.events.create!(
@@ -48,7 +54,7 @@ class Api::ActionNetwork::EventsTest < ActiveSupport::TestCase
     updated_event = Event.any_identifier('action_network:a3c724db-2799-49a6-970a-7c3c0844645d').first!
     assert_equal 'Teach in', updated_event.title, 'Should update title'
 
-    stub_request(:get, 'https://actionnetwork.org/api/v2/events')
+    stub_request(:get, "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'")
       .with(headers: { 'OSDI-API-TOKEN' => group.an_api_key })
       .to_return(body: File.read(Rails.root.join('test', 'fixtures', 'files', 'events2.json')))
 

--- a/test/models/attendance_event_test.rb
+++ b/test/models/attendance_event_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class AttendanceEventTest < ActiveSupport::TestCase
+
+  test 'export_attendace' do
+    attendance = attendances(:seven)
+    attendance_event = attendance.event.attendance_event
+    att_event_id = attendance_event.identifier_id('action_network')
+    event_id = attendance.event.identifier_id('action_network')
+
+    stub_request(:post, url(event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'original_attendance.json')))
+
+    stub_request(:post, url(att_event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'yes_attendance.json')))
+    attendance_identifier = '6216ce97-d826-46fc-a670-a3c3c0d5783f'
+    att_event_identifier = '759e3729-c780-4e68-8d5f-12ff739c719e'
+
+    attendance_event.export_attendace(attendance)
+
+    assert attendance.identifier_id('action_network'), attendance_identifier
+    assert attendance.identifier_id('att_identifier'), att_event_identifier
+  end
+
+  def url(event_id)
+    "https://actionnetwork.org/api/v2/events/#{event_id}/attendances"
+  end
+
+end

--- a/test/models/attendance_test.rb
+++ b/test/models/attendance_test.rb
@@ -11,16 +11,49 @@ class AttendanceTest < ActiveSupport::TestCase
   test 'export' do
     attendance = attendances(:two)
     group = attendance.person.groups.first
-    attendance.update_attribute(:synced, false)
     event_id = attendance.event.identifier_id('action_network')
 
-    stub_request(
-      :post, "https://actionnetwork.org/api/v2/events/#{event_id}/attendances"
-    ).to_return(status: 200)
-
     assert_not attendance.synced
+
+    stub_request(:post, url(event_id)).to_return(status: 200)
+    stub_request(:post, url(event_id)).to_return(status: 200)
+
     attendance.export(group)
     attendance.reload
     assert attendance.synced
+  end
+
+  test 'send_to_action_network_att_event' do
+    attendance = attendances(:seven)
+    att_event_id = attendance.event.attendance_event.identifier_id('action_network')
+    event_id = attendance.event.identifier_id('action_network')
+
+    stub_request(:post, url(event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'original_attendance.json')))
+    stub_request(:post, url(att_event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'yes_attendance.json')))
+
+    assert attendance.send_to_att_event_action_network, true
+
+    attendance.update(attended: false)
+
+    att_event_id = attendance.event.no_attendance_event.identifier_id('action_network')
+    stub_request(:post, url(att_event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'no_attendance.json')))
+
+    assert attendance.send_to_att_event_action_network, true
+  end
+
+  def url(event_id)
+    "https://actionnetwork.org/api/v2/events/#{event_id}/attendances"
   end
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -18,11 +18,14 @@ class GroupTest < ActiveSupport::TestCase
   test "sync_with_action_network" do
     group = Group.first
 
-    stub_request(:get, 'https://actionnetwork.org/api/v2/events')
+    # first request. It should return another page in the next section
+    stub_request(:get, "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'")
       .with(headers: { 'OSDI-API-TOKEN' => group.an_api_key })
       .to_return(body: File.read(Rails.root.join('test', 'fixtures', 'files', 'events.json')))
 
-    stub_request(:get, 'https://actionnetwork.org/api/v2/events?page=2')
+
+    # # second request. It should not return another page in the next section
+    stub_request(:get, "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Action Network'&page=2")
       .with(headers: { 'OSDI-API-TOKEN' => group.an_api_key })
       .to_return(body: File.read(Rails.root.join('test', 'fixtures', 'files', 'events_page_2.json')))
 
@@ -34,7 +37,15 @@ class GroupTest < ActiveSupport::TestCase
       .with(headers: { 'OSDI-API-TOKEN' => group.an_api_key })
       .to_return(body: File.read(Rails.root.join('test', 'fixtures', 'files', 'people_page_2.json')))
 
+    stub_request(:get, "https://actionnetwork.org/api/v2/events/a01e94bf-f132-41c1-a1be-358cc7757119/attendances").
+      with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'Osdi-Api-Token'=>'test-token', 'User-Agent'=>'Ruby'}).
+      to_return(:status => 200, :body => "", :headers => {})
+
+
+    stub_request(:post, 'https://actionnetwork.org/api/v2/events').to_return(status: 200)
+
     %w(
+      bc82a374-fba9-4f47-8e6b-96fdd8350ca2
       1efc3644-af25-4253-90b8-a0baf12dbd1e
       a3c724db-2799-49a6-970a-7c3c0844645d
       d91b4b2e-ae0e-4cd3-9ed7-d0ec501b0bc3
@@ -190,5 +201,9 @@ class GroupTest < ActiveSupport::TestCase
     #   assert_not group.current_group_members, affiliated_member
     #   assert_not_equal group.current_group_members.count, group.members.count + affiliated.members.count
     # end
+
+  def url
+    "https://actionnetwork.org/api/v2/events?filter=origin_system eq 'Affinity'"
+  end
 
 end

--- a/test/models/no_attendance_event_test.rb
+++ b/test/models/no_attendance_event_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class NoAttendanceEventTest < ActiveSupport::TestCase
+
+  test 'export_attendace' do
+    attendance = attendances(:seven)
+    no_attendance_event = attendance.event.no_attendance_event
+    att_event_id = no_attendance_event.identifier_id('action_network')
+    event_id = attendance.event.identifier_id('action_network')
+
+    stub_request(:post, url(event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'original_attendance.json')))
+
+    stub_request(:post, url(att_event_id))
+      .to_return(status: 200,
+                 body: File.read(Rails.root.join('test', 'fixtures', 'files',
+                                                 'attendances',
+                                                 'no_attendance.json')))
+    attendance_identifier = '6216ce97-d826-46fc-a670-a3c3c0d5783f'
+    no_att_identifier = 'f0266b45-1ff1-4680-8221-5f9e1f3046ec'
+
+    no_attendance_event.export_attendace(attendance)
+
+    assert attendance.identifier_id('action_network'), attendance_identifier
+    assert attendance.identifier_id('no_att_identifier'), no_att_identifier
+  end
+
+  def url(event_id)
+    "https://actionnetwork.org/api/v2/events/#{event_id}/attendances"
+  end
+
+end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -94,7 +94,7 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   test 'attended_group_events' do
-    person = Person.create(given_name: 'José', family_name: 'Mejía',)
+    person = Person.create(given_name: 'José', family_name: 'Mejía')
     group_event_attended = Attendance.create(attended: true, person: person, event: Event.first)
     Attendance.create(attended: true, person: person, event: Event.last)
     assert_equal person.attended_group_events(Group.first), [group_event_attended]
@@ -158,11 +158,11 @@ class PersonTest < ActiveSupport::TestCase
   test '#primary_phone_number=' do
     person = Person.create(given_name: 'José', family_name: 'Mejía',)
 
-    person.primary_phone_number = '12341234'
+    person.primary_phone_number = '1234123485'
     person.save
     person.reload
 
-    assert_equal person.primary_phone_number, '12341234'
+    assert_equal person.primary_phone_number, '1234123485'
 
     person.primary_phone_number = ''
     person.save
@@ -339,5 +339,9 @@ class PersonTest < ActiveSupport::TestCase
     new_email_address = EmailAddress.last
     assert_equal email, new_email_address.address
     assert_equal new_person.id, new_email_address.person_id
+  end
+
+  def url(event_id)
+    "https://actionnetwork.org/api/v2/events/#{event_id}/attendances"
   end
 end


### PR DESCRIPTION
- Add filter to only sync event set with origin_system eq Action Network.
- Create ATT/NO_ATT event after create event on affinity.
- Send Attendance ATT/NO_ATT. save the remote identifiers on the original attenface.

closes #328 and closes #430.