### PR TITLE
resolve  "clarify whiteboard description"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -252,7 +252,8 @@ input:checked + .slider:before {
   }
 }
 .text-preview {
-  p {
-    margin: 0;
-  }
+    margin: 2rem 0 2rem 0;
+    p {
+        margin: 0;
+    }
 }

--- a/client/app/bundles/Events/components/TextEditor.jsx
+++ b/client/app/bundles/Events/components/TextEditor.jsx
@@ -98,25 +98,33 @@ class TextEditor extends Component {
 
     return (
       <div className='col-md-12'>
-          <div className='row'>
-            <div className="col-md-3">
-                <h4>Aditional Description</h4>
-            </div>
+        <div className='row'>
+          <div className="col-md-6">
+            <h4>Whiteboard</h4>              
             <UserAuth allowed={['organizer']}>
-              <div className='col-md-12 mb-3'>
-                <button
-                  className='btn btn-primary btn-sm btn-edit'
-                  onClick={this.handleShowEditor.bind(this)}
-                >
-                  <span className='fa fa-pencil-square-o'></span> Edit description
-                </button>
+              <div style={{color: 'lightgray', fontWeight: 'italic'}}>
+                What's important for the group to know?
               </div>
             </UserAuth>
           </div>
+        </div>
 
-          <div className='text-preview'>
-            <div dangerouslySetInnerHTML={{ __html: textValue }} />
-          </div>
+        <div className='text-preview'>
+          <div dangerouslySetInnerHTML={{ __html: textValue }} />
+        </div>
+
+        <div style={{ margin: '1rem 0'}}>
+          <UserAuth allowed={['organizer']}>
+            <div>
+              <button
+                className='btn btn-primary btn-sm btn-edit'
+                onClick={this.handleShowEditor.bind(this)}
+              >
+                <span className='fa fa-pencil-square-o'></span> Edit Whiteboard
+              </button>
+            </div>
+          </UserAuth>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
resolves #568 

# Notes

* Change all instances of "additional description" to "whiteboard"
* Provide greyed-out explainer prompt that only organizers can see
* Move the "edit whiteboard" button below whiteboard content where it doesn't look so dumb
* Spruce up spacing a bit

# Screenshot

![whiteboard-redesign](https://user-images.githubusercontent.com/6032844/38342721-161e8cd8-384e-11e8-83e1-9fc7ff49093a.png)

